### PR TITLE
MainWindow: remove dead code to improve maintainability

### DIFF
--- a/src/main/java/milo/MainWindow.java
+++ b/src/main/java/milo/MainWindow.java
@@ -61,7 +61,7 @@ public class MainWindow extends AnchorPane {
          * If your Milo class has a getCommandType() method, you can pass it here
          * to change the color of the chat bubble.
          */
-        // String commandType = milo.getCommandType();
+
 
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),


### PR DESCRIPTION
The MainWindow class contains several lines of commented-out code that are

no longer in use.

Commented-out code (dead code) litters the codebase and can cause

confusion for future maintainers regarding the current implementation.

Since this logic is preserved in the Git history, there is no need to

keep it in the source file.

Let's remove the unused commented-out blocks in the MainWindow class.

This cleanup aligns with the "Clean Code" principle of keeping the

source files focused only on active, working logic.